### PR TITLE
Update pi.screenrc to use external TOF node

### DIFF
--- a/pi.screenrc
+++ b/pi.screenrc
@@ -67,8 +67,7 @@ stuff "cd $(rospack find pidrone_pkg)/scripts\n"
 stuff "python rigid_transform_node.py"
 
 screen -t "TOF"
-stuff "cd $(rospack find pidrone_pkg)/scripts/\n"
-stuff "python tof_node.py\n"
+stuff "rosrun topic_tools relay /$ROS_HOSTNAME/bottom_tof_driver_node/range /pidrone/range\n"
 
 screen -t "rosbridge"
 stuff "roslaunch --wait rosbridge_server rosbridge_websocket.launch\n"


### PR DESCRIPTION
The ToF driver in `pidrone_pkg` has been deprecated in favor of an external driver running in the `dt-duckiebot-interface` container. This is in order to allow supporting the VL53L1X on the DD24.